### PR TITLE
fix: git clone url of zsh autosuggestions

### DIFF
--- a/tasks/zsh.yml
+++ b/tasks/zsh.yml
@@ -27,7 +27,7 @@
       dir: oh-my-zsh
     - name: https://github.com/zsh-users/zsh-syntax-highlighting
       dir: zsh-syntax-highlighting
-    - name: git://github.com/zsh-users/zsh-autosuggestions
+    - name: https://github.com/zsh-users/zsh-autosuggestions
       dir: zsh-autosuggestions
 
 - name: create conf folder in home directory


### PR DESCRIPTION
## what
fixed git clone repo url of zsh auto suggestions

## why
giving below error while running this ansible common role
```bash
TASK [common : clone oh-my-zsh repo] ****************************************************************************************************************************************
Thursday 29 June 2023  14:42:43 +0530 (0:00:00.034)       0:01:43.663 ********* 

ok: [jenkins-server] => (item={'name': 'https://github.com/robbyrussell/oh-my-zsh', 'dir': 'oh-my-zsh'})
ok: [jenkins-server] => (item={'name': 'https://github.com/zsh-users/zsh-syntax-highlighting', 'dir': 'zsh-syntax-highlighting'})

failed: [jenkins-server] (item={'name': 'git://github.com/zsh-users/zsh-autosuggestions', 'dir': 'zsh-autosuggestions'}) => {"ansible_loop_var": "item", "changed": false, "cmd": "/usr/bin/git ls-remote git://github.com/zsh-users/zsh-autosuggestions -h refs/heads/master", "item": {"dir": "zsh-autosuggestions", "name": "git://github.com/zsh-users/zsh-autosuggestions"}, "msg": "fatal: unable to connect to github.com:\ngithub.com[x.x.x.x]: errno=Connection timed out", "rc": 128, "stderr": "fatal: unable to connect to github.com:\ngithub.com[x.x.x.x]: errno=Connection timed out\n\n", "stderr_lines": ["fatal: unable to connect to github.com:", "github.com[x.x.x.x]: errno=Connection timed out", ""], "stdout": "", "stdout_lines": []}
```